### PR TITLE
chg: dev: Improves file matching for attribute injection using pytest

### DIFF
--- a/lib/topology/pytest/plugin.py
+++ b/lib/topology/pytest/plugin.py
@@ -46,7 +46,7 @@ import logging
 from inspect import stack
 from os import getcwd, makedirs
 from traceback import format_exc
-from os.path import join, isabs, abspath, exists
+from os.path import join, isabs, abspath, exists, isdir
 
 from pytest import fixture, fail, hookimpl, skip
 
@@ -273,7 +273,16 @@ def pytest_configure(config):
     from ..injection import parse_attribute_injection
     injected_attr = None
     if injection_file is not None:
-        injected_attr = parse_attribute_injection(injection_file)
+
+        # Get a list of all testing directories
+        search_paths = [
+            abspath(arg) for arg in config.args if isdir(arg)
+        ]
+
+        injected_attr = parse_attribute_injection(
+            injection_file,
+            search_paths=search_paths
+        )
 
     # Create and register plugin
     config._topology_plugin = TopologyPlugin(

--- a/test/test_topology_injection.py
+++ b/test/test_topology_injection.py
@@ -286,7 +286,7 @@ def test_attribute_injection(tmpdir):
 
         # Actually parse the injection file
         actual = parse_attribute_injection(
-            injection_path, search_path=search_path
+            injection_path, search_paths=[search_path]
         )
 
         # Compare the actual and the expected


### PR DESCRIPTION
With this change the attribute injection file can specify relative wildcards and relative paths from the pytest testing directories arguments.