### PR TITLE
Changes required for new topology connect for work with real devices.

### DIFF
--- a/lib/topology/injection.py
+++ b/lib/topology/injection.py
@@ -155,7 +155,13 @@ def parse_attribute_injection(injection_file, search_paths=None):
                         result[filename][node] = {}
 
                     for attribute, value in modifier['attributes'].items():
-                        result[filename][node][attribute] = value
+                        if isinstance(value, dict):
+                            if attribute in result[filename][node]:
+                                result[filename][node][attribute].update(value)
+                            else:
+                                result[filename][node][attribute] = value
+                        else:
+                            result[filename][node][attribute] = value
 
     log.debug('Attribute injection interpreted dictionary:')
     log.debug(result)

--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -538,6 +538,7 @@ class PExpectShell(BaseShell):
 
         response = '\n'.join(lines)
 
+        # Log response
         if not silent and self._response_logger is not None:
             self._response_logger(response, self._shell)
 

--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -539,8 +539,8 @@ class PExpectShell(BaseShell):
         response = '\n'.join(lines)
 
         # Log response
-        if not silent and self._response_logger is not None:
-            self._response_logger(response, self._shell)
+        if not silent:
+            spawn._connection_logger.log_get_response(response)
 
         return response
 

--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -289,7 +289,7 @@ class BaseShell(object):
          defined, the default connection will be set up.
         """
 
-    def _post_setup_shell(self, connection=None):
+    def _setup_shell(self, connection=None):
         """
         Method called by subclasses that will be triggered after matching the
         initial prompt.
@@ -343,7 +343,7 @@ class PExpectShell(BaseShell):
      the connection.
     :param str initial_prompt: Regular expression that matches the initial
      prompt. This value will be used to match the prompt before calling private
-     method ``_post_setup_shell()``.
+     method ``_setup_shell()``.
     :param str password: Password to be sent at the beginning of the
      connection.
     :param str password_match: Regular expression that matches a password
@@ -515,37 +515,31 @@ class PExpectShell(BaseShell):
         # Get connection
         spawn = self._get_connection(connection)
 
-        response = ''
-        try:
-            # Convert binary representation to unicode using encoding
-            text = spawn.before.decode(self._encoding)
+        # Convert binary representation to unicode using encoding
+        text = spawn.before.decode(self._encoding)
 
-            # Remove leading and trailing whitespaces and normalize newlines
-            text = text.strip().replace('\r', '')
+        # Remove leading and trailing whitespaces and normalize newlines
+        text = text.strip().replace('\r', '')
 
-            # Remove control codes
-            text = regex_sub(TERM_CODES_REGEX, '', text)
+        # Remove control codes
+        text = regex_sub(TERM_CODES_REGEX, '', text)
 
-            # Split text into lines
-            lines = text.splitlines()
+        # Split text into lines
+        lines = text.splitlines()
 
-            # Delete buffer with output right now, as it can be very large
-            del text
+        # Delete buffer with output right now, as it can be very large
+        del text
 
-            # Remove echo command if it exists
-            if self._try_filter_echo and \
-                    lines and self._last_command is not None \
-                    and lines[0].strip() == self._last_command.strip():
-                lines.pop(0)
+        # Remove echo command if it exists
+        if self._try_filter_echo and \
+                lines and self._last_command is not None \
+                and lines[0].strip() == self._last_command.strip():
+            lines.pop(0)
 
-            response = '\n'.join(lines)
+        response = '\n'.join(lines)
 
-            if not silent and self._response_logger is not None:
-                self._response_logger(response, self._shell)
-
-        # if couldn't decode then return raw data
-        except:
-            response = spawn.before
+        if not silent and self._response_logger is not None:
+            self._response_logger(response, self._shell)
 
         return response
 
@@ -641,7 +635,7 @@ class PExpectShell(BaseShell):
                     spawn.send('\n\r')
 
             # Setup shell before using it
-            self._post_setup_shell(connection)
+            self._setup_shell(connection)
 
             # Execute initial command if required
             if self._initial_command is not None:
@@ -709,7 +703,7 @@ class PExpectBashShell(PExpectShell):
     This custom base class will setup the prompt ``PS1`` to the
     ``FORCED_PROMPT`` value of the class and will disable the echo of the
     device by issuing the ``stty -echo`` command. All this is done in the
-    ``_post_setup_shell()`` call, which is overriden by this class.
+    ``_setup_shell()`` call, which is overriden by this class.
     """
     FORCED_PROMPT = '@~~==::BASH_PROMPT::==~~@'
 
@@ -725,7 +719,7 @@ class PExpectBashShell(PExpectShell):
             **kwargs
         )
 
-    def _post_setup_shell(self, connection=None):
+    def _setup_shell(self, connection=None):
         """
         Overriden setup function that will disable the echo on the device on
         the shell and set a pexpect-safe prompt.

--- a/test/test_topology_platforms_shell.py
+++ b/test/test_topology_platforms_shell.py
@@ -329,7 +329,7 @@ def test_connect(spawn, shell):
     def _setup_shell(self, connection=None):
         raise SetupShellError
 
-    shell._post_setup_shell = _setup_shell
+    shell._setup_shell = _setup_shell
 
     with raises(SetupShellError):
         shell.connect()

--- a/test/test_topology_platforms_shell.py
+++ b/test/test_topology_platforms_shell.py
@@ -329,7 +329,7 @@ def test_connect(spawn, shell):
     def _setup_shell(self, connection=None):
         raise SetupShellError
 
-    shell._setup_shell = _setup_shell
+    shell._post_setup_shell = _setup_shell
 
     with raises(SetupShellError):
         shell.connect()


### PR DESCRIPTION
1. Renamed _setup_shell to _pre_setup_shell and introduced _post_setup_shell.
   New one is called before authentication in PExpectShell::connect().
2. Improved PExpectShell::connect() to match not only user shell at the beginning but initial prompt and password as well. Because login username can be specified via connect command("user@server") and then we will need to match password prompt or initial prompt(if password is not required).
3. Improved injection file reading to don't overwrite attribute value, if its value is dictionary but add with new dictionary value.
4. Improved PExpectShell::get_response(). If spawn.before.decode fails then return 'original' text. This may happens, means symbols decode can fails, while DUT is booting and printing a lot of booting log.
5. Changed initial bash prompt in PExpectBashShell::__init() to '\w+@.+[#$] ' as previous don't work for some linux bash promts.