### PR TITLE
chg: dev: Adding timestamps to logs.

### DIFF
--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -562,24 +562,27 @@ class PExpectShell(BaseShell):
         if connection in self._connections and self.is_connected(connection):
             raise AlreadyConnectedError(connection)
 
-        # Inject framework logger to the spawn object
-        spawn_args = {
-            'logfile': get_logger(
-                OrderedDict([
-                    ('node_identifier', self._node_identifier),
-                    ('shell_name', self._shell_name),
-                    ('connection', connection)
-                ]),
-                category='pexpect'
-            ),
-        }
-
-        # Create a child process
-        spawn_args.update(self._spawn_args)
-
         spawn = Spawn(
             self._get_connect_command().strip(),
-            **spawn_args
+            **self._spawn_args
+        )
+
+        spawn.logfile_read = get_logger(
+            OrderedDict([
+                ('node_identifier', self._node_identifier),
+                ('shell_name', self._shell_name),
+                ('connection', connection)
+            ]),
+            category='pexpect_read',
+        )
+
+        spawn.logfile_send = get_logger(
+            OrderedDict([
+                ('node_identifier', self._node_identifier),
+                ('shell_name', self._shell_name),
+                ('connection', connection)
+            ]),
+            category='pexpect_send',
         )
 
         # Add a connection logger

--- a/test/test_topology_platforms_shell.py
+++ b/test/test_topology_platforms_shell.py
@@ -25,14 +25,14 @@ from __future__ import print_function, division
 # mock is located in unittest from Python 3.3 onwards, but as an external
 # package in Python 2.7, that is why the following is done:
 try:
-    from unittest.mock import patch, Mock, call, ANY
+    from unittest.mock import patch, Mock, call
 
     # Work around for http://bugs.python.org/issue25532
     # Prevents infinite memory allocation
     call.__wrapped__ = None
 
 except ImportError:
-    from mock import patch, Mock, call, ANY
+    from mock import patch, Mock, call
 
 from pytest import fixture, raises
 
@@ -104,8 +104,7 @@ def test_spawn_args(spawn, shell):
     shell.connect()
 
     spawn.assert_called_with(
-        'test connection command', echo=False, env={'TERM': 'dumb'},
-        logfile=ANY
+        'test connection command', echo=False, env={'TERM': 'dumb'}
     )
 
     shell = Shell(
@@ -115,8 +114,7 @@ def test_spawn_args(spawn, shell):
     shell.connect()
 
     spawn.assert_called_with(
-        'test connection command', env={'TERM': 'smart'}, echo=True,
-        logfile=ANY
+        'test connection command', env={'TERM': 'smart'}, echo=True
     )
 
 


### PR DESCRIPTION
This separates the pexpect logfile into two, one for reading and other for sending, allowing for more precise control on what is logged and how it is logged. Is used now to timestamp sent logs, but can be expanded for other purposes in the future.