### PR TITLE
chg: dev: tox.ini now uses python3 as base

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
         {envsitepackagesdir}/topology
 
 [testenv:coverage]
+basepython = python3
 commands =
     py.test \
         --junitxml=tests.xml \
@@ -35,6 +36,7 @@ deps =
     -rrequirements.py27.txt
 
 [testenv:doc]
+basepython = python3
 deps =
     -rrequirements.doc.txt
 whitelist_externals =


### PR DESCRIPTION
Without -basepython = python3 tox uses de default python of the system; this ensures tox runs with python 3 no matter the system default