### PR TITLE
fix: dev: Increased delay_after_echo_off a bit

### DIFF
--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -698,7 +698,7 @@ class PExpectBashShell(PExpectShell):
     def __init__(
             self,
             initial_prompt='\w+@.+:.+[#$] ', try_filter_echo=False,
-            delay_after_echo_off=0.15, **kwargs):
+            delay_after_echo_off=0.25, **kwargs):
 
         self._delay_after_echo_off = delay_after_echo_off
 


### PR DESCRIPTION
There are still a few edge cases where bash wasn't able to turn off echo before receiving commands, this slight increase in time is to allow bash enough time to always turn echo off as expected.