### PR TITLE
chg: dev: Modify pexpect logger to match underling data stream

### DIFF
--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -618,6 +618,9 @@ class PExpectShell(BaseShell):
                 ]),
                 category='connection'
             )
+        # Set larger PTTY so there are less unnecessary line
+        # changes on the stream
+        spawn.setwinsize(30, 150)
 
         self._connections[connection] = spawn
 


### PR DESCRIPTION
This change adds a new filehandler that doesn't introduce line changes
arbitrarily. Also Add some line changes on known places to keep output
log file readable. With this changes the log file should match
pexpect's command output stream closer.