### PR TITLE
chg: dev: add FORCED_PROMPT to the initial prompt

### DIFF
--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -714,8 +714,8 @@ class PExpectBashShell(PExpectShell):
 
     def __init__(
             self,
-            initial_prompt='\w+@.+:.+[#$] ', try_filter_echo=False,
-            delay_after_echo_off=1, **kwargs):
+            initial_prompt=['\w+@.+:.+[#$] ', FORCED_PROMPT],
+            try_filter_echo=False, delay_after_echo_off=1, **kwargs):
 
         self._delay_after_echo_off = delay_after_echo_off
 


### PR DESCRIPTION
The original initial prompt does not match the FORCED_PROMPT, this makes the shell to throw a timeout exception when trying to reconnect to a previously used shell.