### PR TITLE
fix: usr: Topology shells will now use pexpect poll() to support more than 1024 file descriptors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-        - "3.4"
+        - "3.5"
 
 before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install -y graphviz
+        - sudo apt-get --quiet=2 update
+        - sudo apt-get --quiet=2 install --yes graphviz
 
 install:
         - pip3 install tox

--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,25 @@
-==========================
-Topology Modular Framework
-==========================
+==================
+Topology Framework
+==================
 
 .. image:: https://travis-ci.org/HPENetworking/topology.svg?branch=master
    :target: https://travis-ci.org/HPENetworking/topology
 
-Advanced modular framework for building and testing network topologies and
-Software.
+Framework for building and testing network topologies, with support for pytest.
 
 
 Documentation
 =============
 
-    http://topology.rtfd.io/
+    https://topology.readthedocs.io/
+
 
 License
 =======
 
-::
+.. code-block:: text
 
-   Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+   Copyright (C) 2015-2019 Hewlett Packard Enterprise Development LP
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,16 +34,33 @@ License
    specific language governing permissions and limitations
    under the License.
 
+
 Changelog
 =========
 
-1.9.15 (2019-11-11)
+
+1.9.15 (2019-11-18)
 -------------------
 
 Changes
 ~~~~~~~
-- Bumping version to 1.9.15 [Diego Dompe]
-- Changes to support newer versions of pytest
+- Removed long ago deprecated module topology.platforms.base [Carlos Jenkins]
+
+    Change imports:
+
+    - topology.platforms.base.BasePlatform => topology.platforms.platform.BasePlatform
+    - topology.platforms.base.BaseNode => topology.platforms.node.BaseNode
+    - topology.platforms.base.CommonNode => topology.platforms.node.CommonNode
+
+- Update BaseShell __call__ and execute to pass args and kwargs to the wrapped
+  call to send_command() (#76) [Sergio Morales]
+- Changes to support newer versions of pytest. (#79) [Diego Dompe]
+- Drop support for Python 3.4. Minimal version is now 3.5. [Carlos Jenkins]
+
+Fix
+~~~
+- Topology shells will now use pexpect poll() to support more than 1024 file
+  descriptors. This change requires pexpect >= 4.6. [Carlos Jenkins]
 
 
 1.9.14 (2018-11-21)
@@ -51,10 +68,6 @@ Changes
 
 Changes
 ~~~~~~~
-- Bumping version to 1.9.14. [Diego Hurtado]
-
-Other
-~~~~~
 - Make new testlog func private. [Matthew Hall]
 
 
@@ -65,13 +78,14 @@ New
 ~~~
 - Environment attributes are now passed to the NMLManager. [Javier
   Peralta]
+- Add functions for new test specific log. [Matthew Hall]
 
 Changes
 ~~~~~~~
 - Remove unit test of functionalty no longer on topology. [Javier
   Peralta]
-- Moving injection to pyszn. [Diego Antonio Hurtado Pimentel]
-- Customize term codes regex. [David Diaz Barquero]
+- Moving injection to pyszn. [Diego Hurtado]
+- Customize term codes regex. [David Diaz]
 
   Add the ability to customize the terminal regex code for special shells
 
@@ -80,32 +94,29 @@ Fix
 - Pyszn uses correct depedency declaration. [Javier Peralta]
 - Minor fixes. [David Diaz]
 
-Other
-~~~~~
-- Add functions for new test specific log. [Matthew Hall]
-
 
 1.9.12 (2018-06-05)
 -------------------
 
-Changes
-~~~~~~~
-- Bumping version to 1.9.12. [Diego Antonio Hurtado Pimentel]
-- Add FORCED_PROMPT to the initial prompt. [Joseph Loaiza]
-
-  The original initial prompt does not match the FORCED_PROMPT, this makes the shell to throw a timeout exception when trying to reconnect to a previously used shell.
-
-Fix
+New
 ~~~
-- Adding missing release information. [Diego Antonio Hurtado Pimentel]
-- Updating to new PEP8 requirements. [Diego Antonio Hurtado Pimentel]
-
-Other
-~~~~~
 - Add a dynamic timeout option. [Matthew Hall]
 
   When this option is used expect will be repeated as long as output is
   still being returned.
+
+Changes
+~~~~~~~
+- Add FORCED_PROMPT to the initial prompt. [Joseph Loaiza]
+
+  The original initial prompt does not match the FORCED_PROMPT, this makes the
+  shell to throw a timeout exception when trying to reconnect to a previously
+  used shell.
+
+Fix
+~~~
+- Adding missing release information. [Diego Hurtado]
+- Updating to new PEP8 requirements. [Diego Hurtado]
 
 
 1.9.11 (2017-11-20)
@@ -126,18 +137,17 @@ Changes
 
 Changes
 ~~~~~~~
-- Extending connection and disconnection arguments. [Diego Antonio
-  Hurtado Pimentel]
+- Extending connection and disconnection arguments. [Diego Hurtado]
 
 Fix
 ~~~
-- Refactoring _get_connection. [Diego Antonio Hurtado Pimentel]
-- Removing support for Python 2.7. [Diego Antonio Hurtado Pimentel]
-- Several fixes in the usage of the connection argument. [Diego Antonio
-  Hurtado Pimentel]
+- Refactoring _get_connection. [Diego Hurtado]
+- Removing support for Python 2.7. [Diego Hurtado]
+- Several fixes in the usage of the connection argument. [Diego Hurtado]
 
   This intentionally breaks compatibility with Python 2.7 since it uses
   syntax introduced in PEP 3102.
+
 - Increase echo sleep 1 second. [Javier Peralta]
 
 
@@ -146,12 +156,7 @@ Fix
 
 New
 ~~~
-- Adding support for sending control characters. [Diego Antonio Hurtado
-  Pimentel]
-
-Changes
-~~~~~~~
-- Bumping version to 1.9.9. [Javier Peralta]
+- Adding support for sending control characters. [Diego Hurtado]
 
 Fix
 ~~~
@@ -163,7 +168,6 @@ Fix
 
 Changes
 ~~~~~~~
-- Refactoring the changelog. [Diego Antonio Hurtado Pimentel]
 - Log python error when plugin load fails. [Javier Peralta]
 
 
@@ -172,12 +176,11 @@ Changes
 
 Fix
 ~~~
-- Add some sleeps to allow bash to turn echo off. [Javier Peralta]
+- Adding a delay after setting echo off. [Javier Peralta]
 
-  Command to set prompt was sometimes too fast and were sent
-  before bash turned off echo (stty -echo) resulting in
-  unwanted information being displayed. This commit makes
-  sure bash always have time to turn echo off.
+  Command to set prompt was sometimes too fast and were sent before bash turned
+  off echo (stty -echo) resulting in unwanted information being displayed. This
+  commit makes sure bash always have time to turn echo off.
 
 
 1.9.6 (2017-05-03)
@@ -185,13 +188,13 @@ Fix
 
 New
 ~~~
-- Add reason to platform_incompatible marker. [David Diaz]
+- Adding reason to ``platform_incompatible`` marker.
+- Adding timestamps to logs.
 
 Changes
 ~~~~~~~
-- Adding timestamps to logs. [Diego Antonio Hurtado Pimentel]
-- Tox.ini now uses python3 as base. [Javier Peralta]
-- Add workaround for bug in mock. [Javier Peralta]
+- Adding workaround for bug in mock.
+- Using ``python3`` as base Python.
 
 
 1.9.5 (2017-01-06)
@@ -199,7 +202,7 @@ Changes
 
 Fix
 ~~~
-- Calling super in init. [Diego Antonio Hurtado Pimentel]
+- Calling missing ``super``.
 
 
 1.9.4 (2016-12-13)
@@ -207,7 +210,7 @@ Fix
 
 Fix
 ~~~
-- Fixing typo in README. [Diego Antonio Hurtado Pimentel]
+- Fixing typo in README.
 
 
 1.9.3 (2016-12-09)
@@ -215,26 +218,16 @@ Fix
 
 Fix
 ~~~
-- Keeping StepLogger backwards compatible. [Diego Antonio Hurtado
-  Pimentel]
+- Making ``StepLogger`` backwards compatible.
 
 
 1.9.2 (2016-12-01)
 ------------------
 
-Changes
-~~~~~~~
-- Refactored step logger to match new logging architecture. [Carlos
-  Jenkins]
-
 Fix
 ~~~
-- Making test_id marker work with the new Pytest. [Diego Antonio Hurtado
-  Pimentel]
-- Calling right class. [Diego Antonio Hurtado Pimentel]
-- Added missing registration of the loggers. [Carlos Jenkins]
-- Minor fixes. [Diego Antonio Hurtado Pimentel]
-- Adding logger for step. [Diego Antonio Hurtado Pimentel]
+- Fixing broken ``step`` logger.
+- Fixing the ``test_id`` marker to make it work with Pytest > 3.0.0.
 
 
 1.9.1 (2016-11-23)
@@ -242,7 +235,7 @@ Fix
 
 Fix
 ~~~
-- Removing fixed dependencies. [Diego Antonio Hurtado Pimentel]
+- Removing fixed dependencies.
 
 
 1.9.0 (2016-11-10)
@@ -250,39 +243,20 @@ Fix
 
 New
 ~~~
-- Documenting --topology-log-dir. [Diego Antonio Hurtado Pimentel]
-- New framework wide logging subsystem. [Diego Antonio Hurtado Pimentel]
+- Adding logging functionality.
 
 Fix
 ~~~
-- Handling decode errors safely. [Diego Antonio Hurtado Pimentel]
-- Fixing wrong usage of _initial_command. [Diego Antonio Hurtado
-  Pimentel]
-- Setting default errors to ignore. [Diego Antonio Hurtado Pimentel]
-
-  The idea of this is to avoid UnicodeDecodeErrors when a undecodeable
-  character shows up in the output that is to be kept by the Pexpect
-  logger by default but to also allow for strict checking if needed.
-- Fixing LEVELS constant. [Diego Antonio Hurtado Pimentel]
-- Fixing log_dir and file_formatter setting. [Diego Antonio Hurtado
-  Pimentel]
+- Fixing the shells connect process.
+- Handling calls to ``decode`` safely.
 
 
 1.8.1 (2016-09-22)
 ------------------
 
-New
-~~~
-- Adding CI spec file. [Diego Antonio Hurtado Pimentel]
-
-Changes
-~~~~~~~
-- Bumping version number to 1.8.1. [Carlos Miguel Jenkins Perez]
-
 Fix
 ~~~
-- Setting right image URL. [Diego Antonio Hurtado Pimentel]
-- Changed deprecated module import. [Carlos Miguel Jenkins Perez]
+- Removed internal imports of deprecated modules.
 
 
 1.8.0 (2016-08-26)
@@ -290,21 +264,17 @@ Fix
 
 New
 ~~~
-- Added a new Services API to manage services running in a node. [Carlos
-  Miguel Jenkins Perez]
-- Adding support for low-level shell API logging. [Diego Antonio Hurtado
-  Pimentel]
-
-  Conflicts:
-  	lib/topology/platforms/base.py
-- Adding user documentation for shell API. [Diego Antonio Hurtado
-  Pimentel]
+- A new ServicesAPI for the nodes is now available. This new API allows to
+  register and later on fetch information about the services a node provides.
+- Greatly improved documentation for the Shell Low Level API introduced in
+  1.4.0. Check "The low-level shell API" in User Guide.
+- The Low Level Shell API will now be able to log user commands. This new
+  feature is backward compatible.
 
 Changes
 ~~~~~~~
-- Bumping version number to 1.8.0. [Carlos Miguel Jenkins Perez]
-- Module ``topology.platforms.base`` is now deprecated. Please change
-  your imports to: [Carlos Miguel Jenkins Perez]
+- Module ``topology.platforms.base`` is now deprecated. Please change your
+  imports to:
 
   ::
 
@@ -312,31 +282,19 @@ Changes
       topology.platforms.base.BaseNode     => topology.platforms.node.BaseNode
       topology.platforms.base.CommonNode   => topology.platforms.node.CommonNode
 
-Fix
-~~~
-- Setting encoding in response logger. [Diego Antonio Hurtado Pimentel]
-- Removing prints from send_command. [Diego Antonio Hurtado Pimentel]
-- Adding missing methods. [Diego Antonio Hurtado Pimentel]
-- Minor documentation fixes, name changes, etc. [Carlos Miguel Jenkins
-  Perez]
-- Minor fixes in documentation and upgrading the AutoAPI plugin for
-  better output format. [Carlos Miguel Jenkins Perez]
-
 
 1.7.2 (2016-06-09)
 ------------------
 
-New
-~~~
-- Adding user matching in PExpectShell. [Diego Antonio Hurtado Pimentel]
-
 Changes
 ~~~~~~~
-- Bumping version number to 1.7.2. [Diego Antonio Hurtado Pimentel]
+- Adding ``user`` as an option for ``PExpectShell`` to support shells that use
+  this kind of authentication.
 
 Fix
 ~~~
-- Adding a missing raise. [Diego Antonio Hurtado Pimentel]
+- Raising the proper exception when a shell connection fails for the user to
+  handle it properly.
 
 
 1.7.1 (2016-05-26)
@@ -344,12 +302,8 @@ Fix
 
 Changes
 ~~~~~~~
-- Bumping version number to 1.7.1. [Diego Antonio Hurtado Pimentel]
-
-Fix
-~~~
-- Removing version requirement for pexpect. [Diego Antonio Hurtado
-  Pimentel]
+- Removing the version requirement of Pexpect since this may cause version
+  collisions with other Python packages commonly used with the framework.
 
 
 1.7.0 (2016-05-26)
@@ -357,101 +311,52 @@ Fix
 
 New
 ~~~
-- Adding support for multiple connections. [Diego Antonio Hurtado
-  Pimentel]
-
-  So far, Topology shells have only supported one connection per
-  shell. This adds multiple-connection functionality to the basic
-  shell classes provided.
-- Adding reference documentation for IP and Ping libraries. [Carlos
-  Miguel Jenkins Perez]
-- Added the reference documentation for the vtysh communication library.
-  [Carlos Miguel Jenkins Perez]
-- Improved documentation a lot. Really. Still a lot to do tought.
-  [Carlos Miguel Jenkins Perez]
+- The reference documentation for the *vtysh*, *ping* and *ip* communication
+  libraries has been added to the documentation.
+- PExpect shells now support multiple connections. This means that the same
+  shell object can now use several ``pexpect`` ``spawn`` objects.
 
 Changes
 ~~~~~~~
-- Bumping version number to 1.7.0. [Diego Antonio Hurtado Pimentel]
-- Exposing Pexpect spawn constructor arguments. [Diego Antonio Hurtado
-  Pimentel]
-- For documentation, better grab from master. [Carlos Miguel Jenkins
-  Perez]
-- Making the new theme official. [Carlos Miguel Jenkins Perez]
-- Porting some key legibility concepts of the Hauntr theme into the
-  Guzzle theme. [Carlos Miguel Jenkins Perez]
-- Improved documentation about communication libraries in the plugin
-  developer guide. [Carlos Miguel Jenkins Perez]
+- The documentation for *communication libraries* has been improved a lot with
+  specific examples for common use cases added.
+- The ``pexpect`` ``spawn`` arguments are now reachable from the initialization
+  of a shell object.
+- The attribute injection feature is now capable of following symbolic links
+  while walking through directory paths.
+- The version of all dependencies has been fixed. This is to avoid unexpected
+  code breaks when a bug is introduced in one of them.
 
 Fix
 ~~~
-- Fixing the version of all dependencies. [Diego Antonio Hurtado
-  Pimentel]
-- Allow walk to iterate through symbolic links. [fonsecamau]
-- Minor documentation fixes. [Carlos Miguel Jenkins Perez]
-- Fixing some minor references to code classes. [Carlos Miguel Jenkins
-  Perez]
-- Other theme minor whitespace and style fixes. [Carlos Miguel Jenkins
-  Perez]
-- Fixed some CSS issues with new theme. [Carlos Miguel Jenkins Perez]
-- Missing history file will no longer show an ERROR when loading the
-  topology executable. [Carlos Miguel Jenkins Perez]
-
-  This fixes #14.
-- Added missing public interface attribute in the BaseNode API. [Carlos
-  Miguel Jenkins Perez]
+- The base node class ``BaseNode`` now includes a ``ports`` attribute. This has
+  been used by all platform engine nodes so far, but was missing in their base
+  class.
+- A missing history file does not raise an error whene executing ``topology``,
+  but is just logged as an error.
+- A few CSS and other theme issues have been fixed.
 
 
 1.6.0 (2016-03-21)
 ------------------
 
-New
-~~~
-- Included image that describes the components of the framework. [Carlos
-  Miguel Jenkins Perez]
-
 Changes
 ~~~~~~~
-- Bumping version number to 1.6.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
-
-  1.6.0: The "Hard rock attribute injection" release.
-
-  **Changes**
-
-  - When expanding the search path for attribute injection all hidden folders
-    (starting with '.') will now be ignored.
-  - When processing files that matched the search path for attribute injection
-    all files that have ill formed / unparseable SZN strings will be logged as
-    error and skipped instead of raising an exception.
-  - When processing files that matched the search path for attribute injection
-    all ``.py``'s that doesn't possess a ``TOPOLOGY`` variable will now be warned
-    and skipped instead of raising an exception.
-
-  **Fixes**
-
-  - Fixed attribute injection crashing when a SZN file is in the node expansion
-    search path.
-  - Fixed rollback routine not being triggered when an non ``Exception`` subclass
-    is raised.
-- When expanding the search path for attribute injection all hidden
-  folders (starting with '.') will now be ignored. [Carlos Miguel
-  Jenkins Perez]
-- When processing files that matched the search path for attribute
-  injection all files that have ill formed / unparseable SZN strings
-  will be logged as error and skipped instead of raising an error.
-  [Carlos Miguel Jenkins Perez]
-- When processing files that matched the search path for attribute
-  injection all .py that doesn't possess a TOPOLOGY will now be warned
-  and skipped instead of raising an error. [Carlos Miguel Jenkins Perez]
+- When expanding the search path for attribute injection all hidden folders
+  (starting with '.') will now be ignored.
+- When processing files that matched the search path for attribute injection
+  all files that have ill formed / unparseable SZN strings will be logged as
+  error and skipped instead of raising an exception.
+- When processing files that matched the search path for attribute injection
+  all ``.py``'s that doesn't possess a ``TOPOLOGY`` variable will now be warned
+  and skipped instead of raising an exception.
 
 Fix
 ~~~
-- Fixed attribute injection when a SZN file is in the node expansion
-  search path. [Carlos Miguel Jenkins Perez]
-- Fixed rollback routine not being triggered when an non Exception
-  subclass is raised. [Carlos Miguel Jenkins Perez]
-- Minor spelling fix. [Carlos Miguel Jenkins Perez]
+- Fixed attribute injection crashing when a SZN file is in the node expansion
+  search path.
+- Fixed rollback routine not being triggered when an non ``Exception`` subclass
+  is raised.
 
 
 1.5.0 (2016-03-02)
@@ -459,18 +364,13 @@ Fix
 
 New
 ~~~
-- New PExpectBashShell class that allows to easily setup shells that
-  uses bash. [Carlos Miguel Jenkins Perez]
-
-Changes
-~~~~~~~
-- Bumping version number to 1.5.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
+- New ``topology.platforms.shell.PExpectBashShell`` class that allows to easily
+  setup shells that uses bash.
 
 Fix
 ~~~
-- Fixed small identation bug that caused the function ``get_shell()`` in
-  the node API to return always None. [Carlos Miguel Jenkins Perez]
+- Fixed small identation bug that caused the function ``get_shell()`` in the
+  node API to return always ``None``.
 
 
 1.4.0 (2016-03-01)
@@ -478,30 +378,27 @@ Fix
 
 New
 ~~~
-- Documenting the new shell API. [Diego Antonio Hurtado Pimentel]
-- New Node API call use_shell() that allows to use a different default
-  shell in a context. [Carlos Miguel Jenkins Perez]
-- New Node API call get_shell() that alows to access the low-level Shell
-  API. [Carlos Miguel Jenkins Perez]
-- New low-level Shell API. [Carlos Miguel Jenkins Perez]
+- New low level shell API that allows to define a common behavior for all low
+  level shell manipulation. This API is implemented by the
+  ``topology.platforms.shell`` module.
+- Two new high level API methods for accesing the low level shell API::
+
+      myshell = mynode.get_shell('python')
+      response = myshell.execute('1 + 1')
+
+  Or using a context manager::
+
+      with mynode.use_shell('python') as python:
+          # This context manager sets the default shell to 'python'
+          mynode('from os import getcwd')
+          cwd = mynode('print(getcwd())')
+
+          # Access to the low-level shell API
+          python.send_command('foo = (', matches=['... '])
 
 Changes
 ~~~~~~~
-- Bumping version number to 1.4.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
-
-Fix
-~~~
-- Logging the command in the debug platform in the same way as in
-  CommonNode. [Carlos Miguel Jenkins Perez]
-- Fixed unbuild when using exit() in the topology executable in
-  interactive mode. [Carlos Miguel Jenkins Perez]
-
-  This fixes issue #11.
-- Fixing shell command prefixing. [Diego Antonio Hurtado Pimentel]
-- Log shell used in send_commands calls. [Carlos Miguel Jenkins Perez]
-
-  This closes issue #5.
+- The shell used to execute a command will now be logged.
 
 
 1.3.0 (2016-02-17)
@@ -509,18 +406,13 @@ Fix
 
 Changes
 ~~~~~~~
-- Bumping version number to 1.3.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
-- Attribute injection will now try to match files on any subfolder of
-  the search paths and not only on the search paths themselves. [Carlos
-  Miguel Jenkins Perez]
-- Updated injection test to reflect the use of search paths. [Carlos
-  Miguel Jenkins Perez]
+- Attribute injection will now try to match files on any subfolder of the
+  search paths and not only on the search paths themselves.
 
 Fix
 ~~~
-- Fixed critical bug in injection attribute not considering matches in
-  some cases. [Carlos Miguel Jenkins Perez]
+- Fixed critical bug in injection attribute not considering matches in some
+  cases.
 
 
 1.2.0 (2016-02-13)
@@ -528,24 +420,18 @@ Fix
 
 New
 ~~~
-- Added documentation for attribute injection feature. [Carlos Miguel
-  Jenkins Perez]
-- New API to BaseNode to allow to change the default shell. [Carlos
-  Miguel Jenkins Perez]
-
-Changes
-~~~~~~~
-- Bumping version number to 1.2.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
-- Improves file matching for attribute injection using pytest testing
-  directories arguments as search paths. [Carlos Miguel Jenkins Perez]
-
-  With this change the attribute injection file can specify relative wildcards and relative paths from the pytest testing directories arguments.
+- Added new API for the topology nodes that allow to set the default shell.
+  For example, you may now use ``mynode.default_shell = 'bash'``.
+- Documentation for the *Attribute Injection* feature was added.
+- Improvements for file matching in attribute injection files. Now, if using
+  pytest, all test folders passed as arguments will be used as search paths for
+  relative files specified in the attribute injection file. With this, it is no
+  longer required to use an absolute path, and this practice becomes deprecated.
 
 Fix
 ~~~
-- Fixing bad matching for attribute=value criteria. [Diego Antonio
-  Hurtado Pimentel]
+- Fixed a bug in attribute injection when using ``attribute=value`` as node
+  identifier that caused all nodes with the attribute to use that value.
 
 
 1.1.0 (2016-01-26)
@@ -553,37 +439,19 @@ Fix
 
 New
 ~~~
-- Added a helper to load nodes for a engine platform. [Carlos Miguel
-  Jenkins Perez]
-- Added the stateprovider decorator to the core. [Carlos Miguel Jenkins
-  Perez]
-
-  The stateprovider decorator allows to easily implement the common
-  pattern of injecting the state of the library into the engine node.
-
-Changes
-~~~~~~~
-- Bumping version number to 1.1.0 for minor release. [Carlos Miguel
-  Jenkins Perez]
+- Added a common ``stateprovider`` decorator to ``topology.libraries.utils``
+  that allows to easily inject state to an enode in a Communication library.
+- Added a common ``NodeLoader`` class to ``topology.platforms.utils`` that
+  allows a Platform Engine to find a load nodes for it's platform.
 
 
 1.0.1 (2016-01-22)
 ------------------
 
-Changes
-~~~~~~~
-- Bumping version to 1.0.1 and adding changelog. [Carlos Miguel Jenkins
-  Perez]
-
 Fix
 ~~~
-- Fixes to consider new pep8 requirements. [Diego Antonio Hurtado
-  Pimentel]
-- Fixed URL of the repository now that it moved. [Carlos Miguel Jenkins
-  Perez]
-- Removing reference to mininet and adding the new URL for
-  topology_docker. [Carlos Miguel Jenkins Perez]
-- Fix topology fails when node has no links (#16) [David Diaz]
+- Fixed fatal bug when running a single node topology without ports.
+- Fixed new PEP8 checks on the codebase.
 
 
 1.0.0 (2016-01-05)
@@ -591,259 +459,4 @@ Fix
 
 New
 ~~~
-- Added enable/disable abstract methods to BaseNode. [Carlos Miguel
-  Jenkins Perez]
-
-  This allow Platform Engines to specify this behaviour in a framework-wide standard way.
-
-  This address issue #4.
-- Added support for injecting attributes when using the topology script.
-  [Carlos Miguel Jenkins Perez]
-- Setting plugin to handle attribute injection. [Diego Antonio Hurtado
-  Pimentel]
-- Adding test for attribute injection. [Diego Antonio Hurtado Pimentel]
-- Handling attribute injection. [Diego Antonio Hurtado Pimentel]
-- Adding parser for attribute injection. [Diego Antonio Hurtado
-  Pimentel]
-- Added the new step fixture to log steps in tests. [Carlos Miguel
-  Jenkins Perez]
-- Added the feature to notify the enodes of their port mapping. [Carlos
-  Miguel Jenkins Perez]
-- Added the unlink and relink call to topology manager and to the
-  platform specification. [Carlos Miguel Jenkins Perez]
-- Added testing for the autoport feature and modified parser to try to
-  interpret some basic datatypes in attributes. [Carlos Miguel Jenkins
-  Perez]
-- Implemented the autoport feature. [Carlos Miguel Jenkins Perez]
-- Implemented the port spec load in topology manager load() function now
-  that the parser can deal with port attributes. [Carlos Miguel Jenkins
-  Perez]
-- Added some architecture documentation. [Carlos Miguel Jenkins Perez]
-- Improved user documentation a lot. [Carlos Miguel Jenkins Perez]
-- Implemented the missing plot and nml export features in the topology
-  executable. [Carlos Miguel Jenkins Perez]
-- Implemented a new parser based on pyparsing that supports port
-  attributes. [Carlos Miguel Jenkins Perez]
-- Added a new incompatible marker to mark specific test as incompatible
-  with a platform engine. [Carlos Miguel Jenkins Perez]
-- Added a new built-in communication library for asserts. [Carlos Miguel
-  Jenkins Perez]
-- Added the feature to extra the TOPOLOGY variable from Python files for
-  the topology executable. [Carlos Miguel Jenkins Perez]
-- Added a very basic documentation for the topology executable. [Carlos
-  Miguel Jenkins Perez]
-- Added an option to hide commands during build to the topology
-  executable. [Carlos Miguel Jenkins Perez]
-- Implemented the topology executable with interactive mode. [Carlos
-  Miguel Jenkins Perez]
-- Added cookiecutter template files for a executable. [Carlos Miguel
-  Jenkins Perez]
-- Added the rollback hook to the base platform class. [Carlos Miguel
-  Jenkins Perez]
-- Implemented echo/silent feature in CommonNode.send_command() to print
-  command and result. [Carlos Miguel Jenkins Perez]
-- Passing port number as metadata. [Carlos Miguel Jenkins Perez]
-- Checking that node identifiers are valid. [Carlos Miguel Jenkins
-  Perez]
-- Implemented the load() method to load the dictionary topology
-  description. [Carlos Miguel Jenkins Perez]
-- Added a new output export NML XML for topologies found. [Carlos Miguel
-  Jenkins Perez]
-- Added a doctest to the manager module to test the workflow. [Carlos
-  Miguel Jenkins Perez]
-- Added support for test_id marker and changed name and semantics of the
-  --topology-plot flag to now be able to specify the folder. [Carlos
-  Miguel Jenkins Perez]
-- Added the auto-plot feature for the pytest plugin. [Carlos Miguel
-  Jenkins Perez]
-- Finished implementing and tested pytest plugin. [Carlos Miguel Jenkins
-  Perez]
-- Added support for positional arguments to be passed from tox to
-  pytest. [Carlos Miguel Jenkins Perez]
-
-  For example:
-
-      tox -e py27 -- --traceconfig
-
-  Will pass the --traceconfig to pytest.
-- Added support for communication libraries for included engine
-  platforms enodes. [Carlos Miguel Jenkins Perez]
-- Added manager for communication libraries. [Carlos Miguel Jenkins
-  Perez]
-- Added a new Debug Engine Paltform to test our codebase for Python 3.4
-  without requiring Mininet (as it doesn't support Python 3) [Carlos
-  Miguel Jenkins Perez]
-- Added a test to test all the build workflow of a TopologyManager.
-  [Carlos Miguel Jenkins Perez]
-- Extended documentation for plugin implementation, in particular for
-  communication libraries. [Carlos Miguel Jenkins Perez]
-
-  Also extended the BaseNode interface to support the documentation.
-- Implemented txtmeta parser in TopologyManager. [Carlos Miguel Jenkins
-  Perez]
-- Add logic to add_biport on mininet plugin. [David Diaz]
-
-  The port is stored inside the plugin but it is not propagated to
-  mininet. When a link is made, the interface will have the correct
-  port number in its name.
-- Added a lot of missing documentation. [Carlos Miguel Jenkins Perez]
-- Added support for Graphviz graphs in Sphinx documentation. [Carlos
-  Miguel Jenkins Perez]
-- Added new documentation for engine platforms plugin developers.
-  [Carlos Miguel Jenkins Perez]
-- Added support for plantUML in Sphinx documentation. [Carlos Miguel
-  Jenkins Perez]
-- Implement send command for mininet plugin. [David Diaz]
-
-  Also add a related test
-- Implement mininet plugin, add nodes and links. [David Diaz]
-
-  Also adds a py.test related
-- Add mininet and pynml to requirements. [David Diaz]
-- Initial version of the topology dot-like syntax parser. [Carlos Miguel
-  Jenkins Perez]
-- Added base pytest plugin for topology. [Carlos Miguel Jenkins Perez]
-- First example of a test using the topology module. [Carlos Miguel
-  Jenkins Perez]
-- Initial base code and draft on the implementation. [Carlos Miguel
-  Jenkins Perez]
-- Initial repository layout. [Carlos Miguel Jenkins Perez]
-
-Changes
-~~~~~~~
-- Changed URLs, version number and requirements for public release.
-  [Carlos Miguel Jenkins Perez]
-- Added timestamp in ISO 8601 format to all commands logging. [Carlos
-  Miguel Jenkins Perez]
-
-  This address issue #8.
-- Update doc to reflect that classes can be defined on libraries. [David
-  Diaz]
-- Libraries are now namespaced. [Carlos Miguel Jenkins Perez]
-- Change assert library name as it is a reserved word. [David Diaz]
-- Rewrote from scratch the communication libraries mechanism for a
-  better approach. [Carlos Miguel Jenkins Perez]
-- Removing autoport and port_number metadata from ports as with the new
-  label metadata they are not required. [Carlos Miguel Jenkins Perez]
-- Added registration of the engine port number to a topology internal
-  structure. [Carlos Miguel Jenkins Perez]
-- Removed the autoport feature from the core framework and changed the
-  approach to a labeled port that must be handled by the platform
-  engine. [Carlos Miguel Jenkins Perez]
-- More crazy stuffs with higly cohesive grouping... [Carlos Miguel
-  Jenkins Perez]
-- Crazy stuffs grouping highly cohesive options... [Carlos Miguel
-  Jenkins Perez]
-- Refactored the platform entry point loader to lazy load the platform
-  and thus avoiding importing all platforms with just the import of the
-  module. [Carlos Miguel Jenkins Perez]
-- Stripping down the mininet platform engine from the core. [Carlos
-  Miguel Jenkins Perez]
-- Refactored the parser module into it's own. [Carlos Miguel Jenkins
-  Perez]
-- Resync repository with template. [Carlos Miguel Jenkins Perez]
-- Changed the way Tox works: [Carlos Miguel Jenkins Perez]
-
-  - Python 3.4 is now the default for everything.
-  - The build is now always done in the temporal directory by default.
-  - Removed tox from requirements.dev.txt as it is not a virtualenv dependency.
-  - The doctest discovery now works.
-- Changed the default platform to be dependent on the interpreter
-  version. [Carlos Miguel Jenkins Perez]
-- Improved internal documentation for the pytest topology plugin.
-  [Carlos Miguel Jenkins Perez]
-- Fixed error reporting for the parser and the plugin. [Carlos Miguel
-  Jenkins Perez]
-- Better changed that when running in Python3 do not skip the plugin
-  test, just ensure a compatible engine, overriding the command line
-  option. [Carlos Miguel Jenkins Perez]
-- Refactored common logic into a CommonNode class. [Carlos Miguel
-  Jenkins Perez]
-- Resynced the repository with it's cookiecutter template and thus we
-  now build the reference documentation with AutoAPI. [Carlos Miguel
-  Jenkins Perez]
-- Add installation instructions related to mininet on documentation.
-  [David Diaz]
-- Fixed mockup nodes using name as identifier and added missing
-  identifier attribute to BaseNode. [Carlos Miguel Jenkins Perez]
-- Changed the shells available to the Mininet Engine nodes and added a
-  placeholder for future communication libraries. [Carlos Miguel Jenkins
-  Perez]
-- Added support for dictmeta format in TOPOLOGY variable to the pytest
-  plugin. [Carlos Miguel Jenkins Perez]
-- Change parameter name on node metadata from variant to type. [David
-  Diaz]
-- Add internal documentation to mininet plugin. [David Diaz]
-- Remove nml manager instance on baseplatform as they are on the
-  constructor. [David Diaz]
-- Added general module documentation. [Diego Antonio Hurtado Pimentel]
-- Updated template for documentation rendering. [Carlos Miguel Jenkins
-  Perez]
-- Moves NMLManager to pynml module. [David Diaz]
-
-Fix
-~~~
-- Passing the correct manager to the topology script namespace. The
-  correct manager is the one that allows to unlink and relink. [Carlos
-  Miguel Jenkins Perez]
-- Removed deprecated attribute. [Carlos Miguel Jenkins Perez]
-- Fixed formatting of the step logger. [Carlos Miguel Jenkins Perez]
-- Fixed return value of the step fixture. [Carlos Miguel Jenkins Perez]
-- Changing shebang of the topology script to Python3. [Carlos Miguel
-  Jenkins Perez]
-- Fixing pytest assert relaunching the command when the asserts fails
-  and a possible non failure on second assert. [Carlos Miguel Jenkins
-  Perez]
-- Fixed bad attribute name. [Carlos Miguel Jenkins Perez]
-- Updated the documentation in the plugin dev guide to reflect change in
-  the workflow. [Carlos Miguel Jenkins Perez]
-- Fixed bad documentation docstring. [Carlos Miguel Jenkins Perez]
-- Unifying the jargon. [Carlos Miguel Jenkins Perez]
-- Minor documentation fixes. [Carlos Miguel Jenkins Perez]
-- Fixed typos and unclear documentation. [Carlos Miguel Jenkins Perez]
-- Fixed non-responsive plantuml diagram. [Carlos Miguel Jenkins Perez]
-- Printing the command previous its call to log adequately for failures.
-  [Carlos Miguel Jenkins Perez]
-- Fixed bug in the way communication libraries functions are called.
-  [Carlos Miguel Jenkins Perez]
-- Fixed a couple of bugs. One related to libraries loading and the other
-  to error messasge printing. [Carlos Miguel Jenkins Perez]
-- Fixed testing of the new feature. [Carlos Miguel Jenkins Perez]
-- Add missing instructions to install graphviz. [Carlos Miguel Jenkins
-  Perez]
-- Fixing stupid ups. [Carlos Miguel Jenkins Perez]
-- Fixed the test_id mark issue when interacting with skipif. [Carlos
-  Miguel Jenkins Perez]
-- Minor style fixes. [Carlos Miguel Jenkins Perez]
-- Check if root on test for pytest plugin, because of mininet. [David
-  Diaz]
-- Fixed building for Python. [Carlos Miguel Jenkins Perez]
-- Fixed abstract metaclass setup for Python 3.4. [Carlos Miguel Jenkins
-  Perez]
-- Fixed a bug with the send_data and send_command function when default
-  and registry is empty. [Carlos Miguel Jenkins Perez]
-- Fixed Python 3.4 compatibility issues. [Carlos Miguel Jenkins Perez]
-- Fixed URL of dependency. [Carlos Miguel Jenkins Perez]
-- Fix module to support Python3. [David Diaz]
-
-  Mininet only works on Python2, so we remove mininet support on Python3
-- Add asserts to check that the topology was build on test. [David Diaz]
-- Fixed again the identifier issue, as 'sw1' is also a rfc3986 valid URI
-  it can be used. Also removed mockup node to use real PyNML nodes.
-  [Carlos Miguel Jenkins Perez]
-- Fix test to check that link was made on the expected port. [David
-  Diaz]
-- Skip mininet tests if not run as root. [David Diaz]
-- Fixed a couple of bugs. [Carlos Miguel Jenkins Perez]
-- Fixed PEP8 warning on setup.py for long line. [Carlos Miguel Jenkins
-  Perez]
-- Fixed entry point lookup to match documentation. [Carlos Miguel
-  Jenkins Perez]
-- Fixed base workflow of platform removal. [Carlos Miguel Jenkins Perez]
-- Finished documenting the base classes for topology platform plugins.
-  [Carlos Miguel Jenkins Perez]
-- Added missing modules to auto reference documentation. [Carlos Miguel
-  Jenkins Perez]
-- Update pynml url on requirements. [David Diaz]
-
-
+- Initial public release.

--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -401,13 +401,15 @@ class PExpectShell(BaseShell):
         self._shell_name = None
         self._errors = errors
         self._testlog = None
-
-        # Doing this to avoid having a mutable object as default value in the
-        # arguments.
-        if spawn_args is None:
-            self._spawn_args = {'env': {'TERM': 'dumb'}, 'echo': False}
-        else:
-            self._spawn_args = spawn_args
+        self._spawn_args = {
+            'env': {'TERM': 'dumb'},
+            'echo': False,
+            # The use_poll attribute enables using select.poll() over
+            # select.select() for socket handling. This is handy if your system
+            # could have > 1024 fds
+            'use_poll': True,
+            **(spawn_args or {})
+        }
 
         self._last_command = None
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,6 @@
-flake8==3.5.0
-pep8-naming==0.4.1
+flake8
+pep8-naming
 pytest>=3.6
-pytest-cov==2.4.0
-deepdiff==1.1.0
-ipdb==0.10.1
--e git+https://github.com/HPENetworking/pyszn.git@master#egg=pyszn
+pytest-cov
+deepdiff
+ipdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 six
-pexpect
+# Why pinning pexpect to 4.6?
+# pexpect 4.5 introduced the use_poll keyword argument to allow
+# using more than 1024 file descriptors by the means of using poll()
+# In 4.6 a bug was fixed in the implementation that hanged and didn't
+# timeout as expected.
+pexpect>=4.6
 pyparsing
 pynml
 pyszn

--- a/test/test_topology_platforms_shell.py
+++ b/test/test_topology_platforms_shell.py
@@ -98,7 +98,10 @@ def test_spawn_args(spawn, shell):
     shell.connect()
 
     spawn.assert_called_with(
-        'test connection command', echo=False, env={'TERM': 'dumb'}
+        'test connection command',
+        env={'TERM': 'dumb'},
+        echo=False,
+        use_poll=True,
     )
 
     shell = Shell(
@@ -108,7 +111,10 @@ def test_spawn_args(spawn, shell):
     shell.connect()
 
     spawn.assert_called_with(
-        'test connection command', env={'TERM': 'smart'}, echo=True
+        'test connection command',
+        env={'TERM': 'smart'},
+        echo=True,
+        use_poll=True,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,19 @@
 [tox]
-envlist = py3, coverage, doc
+envlist = test, doc
+
 
 [testenv]
-passenv = http_proxy https_proxy
+basepython = python3
+passenv = https_proxy http_proxy no_proxy
+
+
+[testenv:test]
 deps =
     -rrequirements.dev.txt
 changedir = {envtmpdir}
 commands =
     {envpython} -c "import topology; print(topology.__file__)"
     flake8 {toxinidir}
-    py.test \
-        {posargs:--topology-platform debug} \
-        {toxinidir}/test \
-        {envsitepackagesdir}/topology
-
-[testenv:coverage]
-basepython = python3
-commands =
     py.test \
         --junitxml=tests.xml \
         --cov=topology \
@@ -28,10 +25,11 @@ commands =
         --topology-plot-dir topologies \
         --topology-plot-format svg \
         {posargs:--topology-platform debug} \
-        {toxinidir}/test {envsitepackagesdir}/topology
+        {toxinidir}/test \
+        {envsitepackagesdir}/topology
+
 
 [testenv:doc]
-basepython = python3
 deps =
     -rrequirements.doc.txt
 whitelist_externals =
@@ -39,8 +37,10 @@ whitelist_externals =
 commands =
     sphinx-build -W -b html -d doctrees {toxinidir}/doc/ html
 
+
 [flake8]
 exclude = .git,.tox,.cache,__pycache__,*.egg-info
+
 
 [pytest]
 addopts = --doctest-modules


### PR DESCRIPTION
This change requires pexpect >= 4.6.