### PR TITLE
chg: usr: Set a meaningful identifier for nml bilinks

### DIFF
--- a/lib/topology/manager.py
+++ b/lib/topology/manager.py
@@ -184,6 +184,10 @@ class TopologyManager(object):
 
             # Explicit-create links
             attrs = deepcopy(link_spec['attributes'])
+            # Set an id for the bilink
+            attrs['identifier'] = ' -- '.join(
+                endpoint.identifier for endpoint in endpoints
+            )
 
             # Inject the run-specific attributes
             if inject is not None and \


### PR DESCRIPTION
Currently the bilinks id is the python instance id, this commit set it
to a combination of the port_ids using the same syntax as pyszn

   node0:port0 -- node1:port1