### PR TITLE
chg: dev: Use realpath for pytest plugin search paths

### DIFF
--- a/lib/topology/libraries/utils.py
+++ b/lib/topology/libraries/utils.py
@@ -61,7 +61,7 @@ def stateprovider(stateclass, statename=None, initfunc=None):
 
     # Set a default statename
     if statename is None:
-        statename = '_lib_state_'.format(stateclass.__name__.lower())
+        statename = '_lib_state_{}'.format(stateclass.__name__.lower())
 
     def decorator(func):
         def replacement(enode, *args, **kwargs):

--- a/lib/topology/logging.py
+++ b/lib/topology/logging.py
@@ -434,7 +434,10 @@ class StepLogger(StdOutLogger):
             '>>> [{:03d}] :: {}:{}\n{}'.format(
                 self.step, execution_context, line_number,
                 '\n'.join(
-                    ['... {}'.format(l) for l in msg.strip().splitlines()]
+                    [
+                        '... {}'.format(line)
+                        for line in msg.strip().splitlines()
+                    ]
                 )
             )
         )

--- a/lib/topology/pytest/plugin.py
+++ b/lib/topology/pytest/plugin.py
@@ -42,7 +42,7 @@ For reference see:
 from os import getcwd, makedirs
 from traceback import format_exc
 from collections import OrderedDict
-from os.path import join, isabs, abspath, exists, isdir
+from os.path import join, isabs, abspath, realpath, exists, isdir
 
 from pytest import fixture, fail, hookimpl, skip
 
@@ -274,7 +274,7 @@ def pytest_configure(config):
 
         # Get a list of all testing directories
         search_paths = [
-            abspath(arg) for arg in config.args if isdir(arg)
+            realpath(arg) for arg in config.args if isdir(arg)
         ]
 
         injected_attr = parse_attribute_injection(


### PR DESCRIPTION
Starting on pytest 3.9.2 pytest resolves symbolic links:
https://github.com/pytest-dev/pytest/pull/4108/

This causes an uncompatibility with the attribute injection feature
as the paths pytest sees (realpaths) differ from the injected_attr
(abspath) found on the topology_plugin.

I am not sure how this impacts #61 

Also I am concerned, topology currently does not specify a particular pytest version and this only works for pytest > 3.9.2 