### PR TITLE
new: usr: Ignore the same paths pytest ignores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ six
 pexpect>=4.6
 pyparsing
 pynml
-pyszn
+pyszn>=1.3.0


### PR DESCRIPTION
When running topology via the pytest plugin, ignore the same paths
pytest does by using norecursedirs ini option.

Also move topology plugin configuration to sessionstart as logs on
pytest are live only after that point.

Depends on https://github.com/HPENetworking/pyszn/pull/7