### PR TITLE
fix: dev: Move argparse type from 'int' to int

### DIFF
--- a/lib/topology/pytest/plugin.py
+++ b/lib/topology/pytest/plugin.py
@@ -237,7 +237,7 @@ def pytest_addoption(parser):
     group.addoption(
         '--topology-build-retries',
         default=0,
-        type='int',
+        type=int,
         help='Retry building a topology up to defined times'
     )
 


### PR DESCRIPTION
In latest version of pytest, the 'int' value as type is no longer supported, causing issues when topology is started.

Here is the error observed: 

```
Traceback (most recent call last):
  File "/home/dev/ws/topology_vdut/.tox/test/bin/py.test", line 8, in <module>
    sys.exit(console_main())
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 197, in console_main
    code = main()
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 155, in main
    config = _prepareconfig(args, plugins)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 337, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/helpconfig.py", line 105, in pytest_cmdline_parse
    config = yield
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1143, in pytest_cmdline_parse
    self.parse(args)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1492, in parse
    self._preparse(args, addopts=addopts)
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1382, in _preparse
    self.known_args_namespace = self._parser.parse_known_args(
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/argparsing.py", line 161, in parse_known_args
    return self.parse_known_and_unknown_args(args, namespace=namespace)[0]
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/argparsing.py", line 175, in parse_known_and_unknown_args
    optparser = self._getparser()
  File "/home/dev/ws/topology_vdut/.tox/test/lib/python3.8/site-packages/_pytest/config/argparsing.py", line 134, in _getparser
    arggroup.add_argument(*n, **a)
  File "/usr/lib/python3.8/argparse.py", line 1385, in add_argument
    raise ValueError('%r is not callable' % (type_func,))
ValueError: 'int' is not callable
test: exit 1 (0.28 seconds) /home/dev/ws/topology_vdut/.tox/test/tmp> py.test /home/dev/ws/topology_vdut/test pid=4555
.pkg: _exit> python /usr/local/lib/python3.8/dist-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  test: FAIL code 1 (1.32=setup[0.93]+cmd[0.11,0.00,0.28] seconds)
```

After printing all the parse parameters, the one causing issues was `--topology-build-retries`. This issue was observed in pytest version `8.1.1`. 

Additionally, the parse arg type is not meant to be a string: https://docs.python.org/es/3/library/argparse.html#argparse-type

With this change, the issue goes away