### PR TITLE
Support python 3.12

### DIFF
--- a/lib/topology/args.py
+++ b/lib/topology/args.py
@@ -20,11 +20,10 @@ Argument management module.
 """
 
 import logging
-from os import getcwd
 from re import compile
 from pprint import pformat
+from os import getcwd, makedirs
 from collections import OrderedDict
-from distutils.dir_util import mkpath
 from argparse import Action, ArgumentParser
 from os.path import join, isabs, abspath, isfile
 
@@ -215,7 +214,7 @@ def validate_args(args):
     if args.log_dir:
         if not isabs(args.log_dir):
             args.log_dir = join(abspath(getcwd()), args.log_dir)
-        mkpath(args.log_dir)
+        makedirs(args.log_dir, exist_ok=True)
 
     # Parse options
     if args.options:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ passenv = https_proxy, http_proxy, no_proxy
 skip_install = True
 deps =
     wheel
+    setuptools
 changedir = {toxinidir}
 commands =
     {envpython} setup.py sdist
@@ -20,6 +21,7 @@ commands =
 
 [testenv:test]
 deps =
+    setuptools
     -rtest/requirements.txt
 commands =
     {envpython} -c "import topology; print(topology.__file__)"
@@ -37,6 +39,7 @@ commands =
 
 [testenv:doc]
 deps =
+    setuptools
     -rdoc/requirements.txt
 allowlist_externals =
     dot


### PR DESCRIPTION
* Remove distutils references (it was removed on python3.12)
* Add setuptools as dependency on tox environments (see https://github.com/python/cpython/issues/95299)