### PR TITLE
Update regex to parse terminal output

### DIFF
--- a/lib/topology/platforms/shell.py
+++ b/lib/topology/platforms/shell.py
@@ -34,8 +34,7 @@ from pexpect import TIMEOUT
 
 from topology.logging import get_logger
 
-
-TERM_CODES_REGEX = r'\x1b[E|\[](\?)?([0-9]{1,2}(;[0-9]{1,2})?)?[m|K|h|H|r]?'
+TERM_CODES_REGEX = r'\x1B[@-_][0-?]*[ -/]*[@-~]'
 """
 Regular expression to match terminal control codes.
 
@@ -48,23 +47,16 @@ This regular expression allows to remove them as they are unneeded for the
 purpose of executing commands and parsing their outputs
 (unless proven otherwise).
 
-``\\x1b``
-  Match prefix that indicates the next characters are part of a terminal code
-  string.
-``[E|\\[]``
-  Match either ``E`` or ``[``.
-``(\\?)?``
-  Match zero or one ``?``.
-``([0-9]{1,2}``
-  Match 1 or 2 numerical digits.
-``(;[0-9]{1,2})?``
-  Match zero or one occurences of the following pattern: ``;`` followed by 1
-  or 2 numerical digits.
-``)?``
-  Means the pattern composed by the the last 2 parts above can be found zero or
-  one times.
-``[m|K|h|H|r]?``
-  Match zero or one occurrences of either ``m``, ``K``, ``h``, ``H`` or ``r``.
+This pattern works as follows:
+
+``\x1B[@-_]``: Matches the escape character (ASCII code 27) followed by any
+character in the range from @ to _.
+``[0-?]*``: Matches zero or more characters in the range from 0 to ?.
+``[ -/]*``: Matches zero or more characters in the range from space to /.
+``[@-~]``: Matches a single character in the range from @ to ~.
+
+This should cover a wide variety of ANSI escape sequences, including those for
+text formatting, cursor movement, and other terminal control codes.
 """
 
 


### PR DESCRIPTION
The current regex fails to clear some ANSI escape characters from the
terminal output. This commit adds a more generic pattern to catch these
cases.

Trying to use a docker node running Ubuntu 22.04 it was found that the
get_response command was returning extra characters in the output.
Behavior not found on Ubuntu 20.04.

Example:
When running the command `send_command('which catchsegv', matches=['@~~==::BASH_PROMPT::==~~@'],
newline=True, timeout=None)`, and then  `get_response()`, the output would
be `04l/usr/bin/catchsegv04h`. Notice the extra characters `04l` and `04h`
wrapping the output. These correspond to ANSI escape characters leftovers.

For example, the current pattern would leave in `49h` if `ESC[?1049h` was
received. With the updated pattern the whole escape sequence is removed.