### PR TITLE
Replace pkg_resources with importlib.metadata for entry point handling

### DIFF
--- a/lib/topology/libraries/manager.py
+++ b/lib/topology/libraries/manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+# Copyright (C) 2015-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,11 @@ from traceback import format_exc
 from collections import OrderedDict
 from argparse import Namespace
 
-from pkg_resources import iter_entry_points
+import sys
+if sys.version_info >= (3, 8):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points  # backport for Python < 3.8
 
 
 log = logging.getLogger(__name__)
@@ -70,7 +74,7 @@ def libraries(cache=True):
     available = {}
 
     # Iterate over entry points
-    for ep in iter_entry_points(group='topology_library_10'):
+    for ep in entry_points(group='topology_library_10'):
 
         name = ep.name
 

--- a/lib/topology/platforms/manager.py
+++ b/lib/topology/platforms/manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+# Copyright (C) 2015-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,11 @@ from __future__ import print_function, division
 import logging
 from inspect import isclass
 
-from pkg_resources import iter_entry_points
+import sys
+if sys.version_info >= (3, 8):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points  # backport for Python < 3.8
 
 from .platform import BasePlatform
 
@@ -63,7 +67,7 @@ def platforms(cache=True):
     available = []
 
     # Iterate over entry points
-    for ep in iter_entry_points(group='topology_platform_10'):
+    for ep in entry_points(group='topology_platform_10'):
         available.append(ep.name)
 
     available.sort()
@@ -85,7 +89,7 @@ def load_platform(name):
         raise RuntimeError('Unknown platform engine "{}".'.format(name))
 
     # Iterate over entry points
-    for ep in iter_entry_points(group='topology_platform_10', name=name):
+    for ep in entry_points(group='topology_platform_10', name=name):
 
         try:
             platform = ep.load()

--- a/lib/topology/platforms/utils.py
+++ b/lib/topology/platforms/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+# Copyright (C) 2015-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,11 @@ from inspect import isclass
 from traceback import format_exc
 from collections import OrderedDict
 
-from pkg_resources import iter_entry_points
+import sys
+if sys.version_info >= (3, 8):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points  # backport for Python < 3.8
 
 from .node import BaseNode
 
@@ -88,7 +92,7 @@ class NodeLoader(object):
         available = OrderedDict()
 
         # Iterate over entry points
-        for ep in iter_entry_points(group=self.entrypoint):
+        for ep in entry_points(group=self.entrypoint):
 
             name = ep.name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+importlib-metadata; python_version < "3.8"
 six
 # Why pinning pexpect to 4.6?
 # pexpect 4.5 introduced the use_poll keyword argument to allow


### PR DESCRIPTION
```sh 
----/lib/python3.12/site-packages/topology/platforms/manager.py:31: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
```