### PR TITLE
Add option to group tests by topology

### DIFF
--- a/lib/topology/__init__.py
+++ b/lib/topology/__init__.py
@@ -21,4 +21,4 @@ topology module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.19.4'
+__version__ = '1.20.0'

--- a/lib/topology/pytest/__init__.py
+++ b/lib/topology/pytest/__init__.py
@@ -18,6 +18,3 @@
 """
 topology pytest plugin module entry point.
 """
-
-from __future__ import unicode_literals, absolute_import
-from __future__ import print_function, division

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pynml
 pyszn>=1.4.0
 typing_extensions
 pprintpp
+deepdiff

--- a/test/szn/ring.szn
+++ b/test/szn/ring.szn
@@ -1,0 +1,28 @@
+# Nodes
+[type=type1 name="Switch 1"] sw1
+[type=type1 name="Switch 2"] sw2
+[type=type2 name="Switch 2"] sw3
+
+
+#
+#  +---------+       +---------+
+#  |         |1    1 |         |
+#  | sw1     ---------  sw2    |
+#  |         |       |         |
+#  +--|------+       +-----|---+
+#     |10                  |20
+#     |                    |
+#     |                    |
+#     |    +---------+     |
+#     |    |         |     |
+#     +------ sw3    |-----+
+#       10 |         | 20
+#          +---------+
+# Links
+sw1:1 -- sw2:1
+[stack=true] sw1:10 -- sw3:10
+[stack=true] sw2:20 -- sw3:20
+
+# Ports
+[speed=1g] sw1:1 sw1:2
+[speed=10g] sw1:10 sw2:20 sw3:10 sw3:20

--- a/test/test_topology_id.py
+++ b/test/test_topology_id.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2025 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Test suite for TOPOLOGY_ID feature.
+"""
+
+TOPOLOGY_ID = 'ring'
+
+
+def test_topology_id(topology, pytestconfig):
+    """
+    Verify that when topology_szn_dir is set, the topology is built
+    correctly from the SZN files.
+    """
+    assert pytestconfig.getoption('--topology-szn-dir')
+    assert topology.get('sw1') is not None
+    assert topology.get('sw2') is not None
+    assert topology.get('sw3') is not None

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ commands =
         --cov-report html \
         --cov-report term \
         --cov-config={toxinidir}/test/.coveragerc \
-        {posargs:--topology-platform debug} \
+        --topology-platform debug --topology-szn-dir {toxinidir}/test/szn \
+        {posargs} \
         {toxinidir}/test
 
 


### PR DESCRIPTION
Now when --topology-group-by-topology pytest
option is provided, any tests that share
the same topology string, szn and injected
attributes are run using the same topology
manager instance. This means the topology
is built only once per group of tests
instead of once per test, reducing the
execution time.

In addition, --topology-topologies-file
controls the path to a json file where the
info of each topology group and its
respective tests is written.