### PR TITLE
Save topology manager instance within the pytest plugin

### DIFF
--- a/lib/topology/__init__.py
+++ b/lib/topology/__init__.py
@@ -21,4 +21,4 @@ topology module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.20.2'
+__version__ = '1.20.3'


### PR DESCRIPTION
This allows other hooks and pytest fixtures obtain information about the topology.