### PR TITLE
Change topology fixture scope from module to function

### DIFF
--- a/lib/topology/__init__.py
+++ b/lib/topology/__init__.py
@@ -21,4 +21,4 @@ topology module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.20.4'
+__version__ = '1.20.5'


### PR DESCRIPTION
This causes the pytest topology fixture to run before any test instead of before any module. The change takes care of keeping the same behavior of building the topology once per module when not grouping by topology.